### PR TITLE
supermicro/x10sll-f: init

### DIFF
--- a/supermicro/x10sll-f.nix
+++ b/supermicro/x10sll-f.nix
@@ -1,0 +1,14 @@
+{ config, pkgs, ... }:
+
+{
+  environment.systemPackages = with pkgs; [
+    ipmitool
+  ];
+
+  boot.kernelModules = [ "jc42" "ipmi_devintf" "ipmi_si" "tpm_rng" ];
+
+  # services.cron.systemCronJobs = [
+  #   # Reset 5-minute watchdog timer every minute
+  #   "* * * * * ${pkgs.ipmitool}/bin/ipmitool raw 0x30 0x97 1 5"
+  # ];
+}


### PR DESCRIPTION
This adds necessary kernel modules to control IPMI and hardware random generator from TPM. I also have a watchdog module enabled, but here it is commented because enabling it by default is not a good idea IMO. I left it as an example, however.