### PR TITLE
Thinkpad X220i: configure more hardware

### DIFF
--- a/lenovo/x220i-tablet.nix
+++ b/lenovo/x220i-tablet.nix
@@ -11,4 +11,23 @@
 
   # TLP Linux Advanced Power Management
   services.tlp.enable = true;
+
+  # hard disk protection if the laptop falls
+  services.hdapsd.enable = true;
+
+  # trackpoint support (touchpad disabled in this config)
+  hardware.trackpoint.enable = true;
+  hardware.trackpoint.emulateWheel = true;
+
+  # alternatively, touchpad with two-finger scrolling
+  #services.xserver.libinput.enable = true;
+
+  # enable volume control buttons
+  sound.enableMediaKeys = true;
+
+  # fingerprint reader: login and unlock with fingerprint (if you add one with `fprintd-enroll`)
+  #services.fprintd.enable = true;
+  #security.pam.services.login.fprintAuth = true;
+  #security.pam.services.xscreensaver.fprintAuth = true;
+  # similarly for other PAM providers
 }


### PR DESCRIPTION
Here's a patch that shows how to add support for

 - TrackPoint
 - (alternatively) better touchpad support
 - volume/mute buttons
 - active hard-drive protection
 - fingerprint reader

I've been using these options for a couple of days on a non-tablet X220i. See https://github.com/dancek/dotfiles/blob/master/nixos/thinkpad-x220i/configuration.nix